### PR TITLE
Fix --for-browser with relative main field

### DIFF
--- a/pax/examples/browser/index.js
+++ b/pax/examples/browser/index.js
@@ -1,4 +1,5 @@
 const alternateMain = require('alternate-main');
+const relativeMain = require('relative-main');
 const alternateFiles = require('alternate-files/foo');
 const alternateFilesNested = require('alternate-files/nested/foo');
 const alternateFilesInternal = require('alternate-files/internal-import');
@@ -9,6 +10,7 @@ const ignored = require('ignored');
 
 console.log('In browser should be true and false otherwise');
 console.log('alternateMain:', alternateMain.isBrowser);
+console.log('relativeMain:', relativeMain.isBrowser);
 console.log('alternateFiles:', alternateFiles.isBrowser);
 console.log('alternateFilesNested:', alternateFilesNested.isBrowser);
 console.log('alternateFilesInternal:', alternateFilesInternal.isBrowser);

--- a/pax/examples/browser/node_modules/relative-main/index-browser.js
+++ b/pax/examples/browser/node_modules/relative-main/index-browser.js
@@ -1,0 +1,2 @@
+module.exports = {isBrowser: true}
+

--- a/pax/examples/browser/node_modules/relative-main/index.js
+++ b/pax/examples/browser/node_modules/relative-main/index.js
@@ -1,0 +1,2 @@
+module.exports = {isBrowser: false}
+

--- a/pax/examples/browser/node_modules/relative-main/package.json
+++ b/pax/examples/browser/node_modules/relative-main/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "index.js",
+  "browser": "index-browser.js"
+}

--- a/pax/src/main.rs
+++ b/pax/src/main.rs
@@ -1758,8 +1758,15 @@ impl BrowserField {
                 if !to.is_explicitly_relative() {
                     to.prepend_resolving(Path::new("."));
                 }
+
+                let mut from = main.to_owned();
+
+                if !from.is_explicitly_relative() {
+                    from.prepend_resolving(Path::new("."));
+                }
+
                 BrowserSubstitutionMap(map! {
-                    main.to_owned() => BrowserSubstitution::Replace(to),
+                    from => BrowserSubstitution::Replace(to),
                 })
             }
             BrowserField::Complex(map) => map,


### PR DESCRIPTION
When both main and browser are specified in package.json, browser is not correctly resolved when main is a relative path.

I think this may also fix the issue in https://github.com/nathan/pax/issues/78

Paired with @chromy 